### PR TITLE
Update Makefile.hipfort

### DIFF
--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -20,7 +20,7 @@
 
 HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
-CUDA            ?= /usr/local/cuda
+CUDA_PATH       ?= /usr/local/cuda
 HIPFORT_COMPILER ?= gfortran
 ROCM_PATH=${ROCM_PATH:-/opt/rocm}
 DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
@@ -33,7 +33,7 @@ HIP_PLATFORM=${HIP_PLATFORM:-amd}
 GPU = $(strip $(subst ., ,$(suffix $(subst -,.,$(HIPFORT_ARCHGPU)))))
 ifeq (nvptx,$(findstring nvptx,$(HIPFORT_ARCHGPU)))
   UNAMEP     = $(shell uname -p)
-  LINKOPTS   = -L$(LIB_DIR) -lhipfort-$(ARCH) -L$(CUDA)/targets/$(UNAMEP)-linux/lib $(LINKOPTS) -lcudart
+  LINKOPTS   = -L$(LIB_DIR) -lhipfort-$(ARCH) -L$(CUDA_PATH)/targets/$(UNAMEP)-linux/lib $(LINKOPTS) -lcudart
   HIPCC_ENV  = HIP_PLATFORM=nvcc
   HIPCC_OPTS = "--gpu-architecture=$(GPU)"
 else

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -21,7 +21,7 @@
 HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
 HIPFORT_COMPILER ?= gfortran
-CUDA_PATH=${ROCM_PATH:-/usr/local/cuda}
+CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
 ROCM_PATH=${ROCM_PATH:-/opt/rocm}
 DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
 HIP_CLANG_PATH   ?= $(ROCM_PATH)/llvm/bin

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -37,7 +37,7 @@ ifeq (nvptx,$(findstring nvptx,$(HIPFORT_ARCHGPU)))
   HIPCC_ENV  = HIP_PLATFORM=nvcc
   HIPCC_OPTS = "--gpu-architecture=$(GPU)"
 else
-  LINKOPTS   = -L$(LIB_DIR) -lhipfort-$(ARCH) -L$(ROCM)/lib $(HIPCC_LIBS) -lamdhip64 -Wl,-rpath=$(ROCM)/lib
+  LINKOPTS   = -L$(LIB_DIR) -lhipfort-$(ARCH) -L$(ROCM_PATH)/lib $(HIPCC_LIBS) -lamdhip64 -Wl,-rpath=$(ROCM_PATH)/lib
   HIPCC_ENV  = HIP_PLATFORM=$(HIP_PLATFORM) DEVICE_LIB_PATH=$(DEVICE_LIB_PATH) HIP_CLANG_PATH=$(HIP_CLANG_PATH)
   HIPCC_OPTS = -fno-gpu-rdc -fPIC --offload-arch=$(GPU)
 endif

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -18,16 +18,17 @@
 #    HIPFORT_ARCHGPU = nvptx-sm_70
 #
 
-ROCM            ?= /opt/rocm
 HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
 CUDA            ?= /usr/local/cuda
 HIPFORT_COMPILER ?= gfortran
-DEVICE_LIB_PATH  ?= $(ROCM)/lib
-HIP_CLANG_PATH   ?= $(ROCM)/llvm/bin
+ROCM_PATH=${ROCM_PATH:-/opt/rocm}
+DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
+HIP_CLANG_PATH   ?= $(ROCM_PATH)/llvm/bin
 
 MOD_DIR  = $(HIPFORT_HOME)/include/$(ARCH)
 LIB_DIR  = $(HIPFORT_HOME)/lib
+HIP_PLATFORM=${HIP_PLATFORM:-amd}
 
 GPU = $(strip $(subst ., ,$(suffix $(subst -,.,$(HIPFORT_ARCHGPU)))))
 ifeq (nvptx,$(findstring nvptx,$(HIPFORT_ARCHGPU)))
@@ -37,11 +38,11 @@ ifeq (nvptx,$(findstring nvptx,$(HIPFORT_ARCHGPU)))
   HIPCC_OPTS = "--gpu-architecture=$(GPU)"
 else
   LINKOPTS   = -L$(LIB_DIR) -lhipfort-$(ARCH) -L$(ROCM)/lib $(HIPCC_LIBS) -lamdhip64 -Wl,-rpath=$(ROCM)/lib
-  HIPCC_ENV  = HIP_PLATFORM=hcc DEVICE_LIB_PATH=$(DEVICE_LIB_PATH) HIP_CLANG_PATH=$(HIP_CLANG_PATH)
+  HIPCC_ENV  = HIP_PLATFORM=$(HIP_PLATFORM) DEVICE_LIB_PATH=$(DEVICE_LIB_PATH) HIP_CLANG_PATH=$(HIP_CLANG_PATH)
   HIPCC_OPTS = -fno-gpu-rdc -fPIC --offload-arch=$(GPU)
 endif
 
 LINKOPTS += -lstdc++
-CXX      = $(HIPCC_ENV) $(ROCM)/bin/hipcc $(HIPCC_OPTS)
+CXX      = $(HIPCC_ENV) $(ROCM_PATH)/bin/hipcc $(HIPCC_OPTS)
 FC_OPTS  = "-DHIPFORT_ARCH=\"$(ARCH)\""
 FC       = $(HIPFORT_COMPILER) -cpp -I$(MOD_DIR) $(FC_OPTS)

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -20,8 +20,8 @@
 
 HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
-CUDA_PATH       ?= /usr/local/cuda
 HIPFORT_COMPILER ?= gfortran
+CUDA_PATH=${ROCM_PATH:-/usr/local/cuda}
 ROCM_PATH=${ROCM_PATH:-/opt/rocm}
 DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
 HIP_CLANG_PATH   ?= $(ROCM_PATH)/llvm/bin

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -25,10 +25,10 @@ CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
 ROCM_PATH=${ROCM_PATH:-/opt/rocm}
 DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
 HIP_CLANG_PATH   ?= $(ROCM_PATH)/llvm/bin
+HIP_PLATFORM=${HIP_PLATFORM:-amd}
 
 MOD_DIR  = $(HIPFORT_HOME)/include/$(ARCH)
 LIB_DIR  = $(HIPFORT_HOME)/lib
-HIP_PLATFORM=${HIP_PLATFORM:-amd}
 
 GPU = $(strip $(subst ., ,$(suffix $(subst -,.,$(HIPFORT_ARCHGPU)))))
 ifeq (nvptx,$(findstring nvptx,$(HIPFORT_ARCHGPU)))


### PR DESCRIPTION
Changed to widely used variable ROCM_PATH. HIP_PLATFORM is now "amd" instead of "hcc"
HIP_PLATFORM=${HIP_PLATFORM:-amd}
ROCM_PATH=${ROCM_PATH:-/opt/rocm}