### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ if(NOT CPACK_PACKAGING_INSTALL_PREFIX)
 endif()
 
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" )
+# Prevent rpmbuild from stripping binaries, which caused issues on CentOS
+set(CPACK_RPM_SPEC_INSTALL_POST "/bin/true")
 
 rocm_create_package(
   NAME hipfort


### PR DESCRIPTION
Prevent rpm-build to stripping binaries, which caused linker issues on CentOS 8.

More information:

* https://iangilham.com/2016/12/08/preventing-rpmbuild-stripping-symbols-with-cpack.html
* https://gitlab.kitware.com/cmake/community/-/wikis/doc/cpack/PackageGenerators#cpack-rpm-generators-specific-settings
* https://public.kitware.com/Bug/view.php?id=7435