### PR TITLE
bugfix/centos77: Pass scalars to c_loc (WiP)

### DIFF
--- a/test/f2003/hipblas/cgemm.f03
+++ b/test/f2003/hipblas/cgemm.f03
@@ -61,16 +61,16 @@ program hip_dgemm
   call hipCheck(hipMalloc(dc,Ncbytes))
 
   !Transfer from host to device
-  call hipCheck(hipMemcpy(da, c_loc(ha), Nabytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(db, c_loc(hb), Nbbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dc, c_loc(hc), Ncbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(da, c_loc(ha(1,1)), Nabytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(db, c_loc(hb(1,1)), Nbbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dc, c_loc(hc(1,1)), Ncbytes, hipMemcpyHostToDevice))
 
   call hipblasCheck(hipblasCgemm(handle,transa,transb,m,n,k,alpha,da,lda,db,ldb,beta,dc,ldc))
 
   call hipCheck(hipDeviceSynchronize())
 
   ! Transfer data back to host memory
-  call hipCheck(hipMemcpy(c_loc(hc), dc, Ncbytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hc(1,1)), dc, Ncbytes, hipMemcpyDeviceToHost))
 
   do i = 1,m
   do j = 1,n

--- a/test/f2003/hipblas/dgemm.f03
+++ b/test/f2003/hipblas/dgemm.f03
@@ -60,9 +60,9 @@ program hip_dgemm
   call hipCheck(hipMalloc(dc,Ncbytes))
 
   !Transfer from host to device
-  call hipCheck(hipMemcpy(da, c_loc(ha), Nabytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(db, c_loc(hb), Nbbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dc, c_loc(hc), Ncbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(da, c_loc(ha(1)), Nabytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(db, c_loc(hb(1)), Nbbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dc, c_loc(hc(1)), Ncbytes, hipMemcpyHostToDevice))
 
 
   call hipblasCheck(hipblasDgemm(handle,transa,transb,m,n,k,alpha,da,lda,db,ldb,beta,dc,ldc))
@@ -70,7 +70,7 @@ program hip_dgemm
   call hipCheck(hipDeviceSynchronize())
 
   ! Transfer data back to host memory
-  call hipCheck(hipMemcpy(c_loc(hc), dc, Ncbytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hc(1)), dc, Ncbytes, hipMemcpyDeviceToHost))
 
 
   do i = 1,size_c

--- a/test/f2003/hipblas/dger.f03
+++ b/test/f2003/hipblas/dger.f03
@@ -38,16 +38,16 @@ program hip_dger
   call hipCheck(hipMalloc(dA,Nbytes*n))
 
   !Transfer from host to device
-  call hipCheck(hipMemcpy(dx, c_loc(hx), Nbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dy, c_loc(hy), Nbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dA, c_loc(hA), Nbytes*n, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(hx(1)), Nbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dy, c_loc(hy(1)), Nbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dA, c_loc(hA(1)), Nbytes*n, hipMemcpyHostToDevice))
 
   call hipblasCheck(hipblasDger(handle,m,n,alpha,dx,1,dy,1,dA,m))
 
   call hipCheck(hipDeviceSynchronize())
 
   ! Transfer data back to host memory
-  call hipCheck(hipMemcpy(c_loc(hA), dA, Nbytes*n, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hA(1)), dA, Nbytes*n, hipMemcpyDeviceToHost))
 
   do i = 1,m*n
      error = abs(2.1d0 - hA(i))

--- a/test/f2003/hipblas/dscal.f03
+++ b/test/f2003/hipblas/dscal.f03
@@ -38,14 +38,14 @@ program hip_dscal
   call hipCheck(hipMalloc(dx,Nbytes))
 
    ! Transfer data from host to device memory
-  call hipCheck(hipMemcpy(dx, c_loc(hx), Nbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(hx(1)), Nbytes, hipMemcpyHostToDevice))
 
   call hipblasCheck(hipblasDscal(hip_blas_handle, N, alpha, dx, 1))
 
   call hipCheck(hipDeviceSynchronize())
 
   ! Transfer data back to host memory
-  call hipCheck(hipMemcpy(c_loc(hx), dx, Nbytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hx(1)), dx, Nbytes, hipMemcpyDeviceToHost))
 
   call hipCheck(hipFree(dx))
 

--- a/test/f2003/hipblas/saxpy.f03
+++ b/test/f2003/hipblas/saxpy.f03
@@ -45,14 +45,14 @@ program hip_saxpy
   call hipCheck(hipMalloc(dx,Nxbytes))
   call hipCheck(hipMalloc(dy,Nybytes))
 
-  call hipCheck(hipMemcpy(dx, c_loc(x), Nxbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dy, c_loc(y), Nybytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(x(1)), Nxbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dy, c_loc(y(1)), Nybytes, hipMemcpyHostToDevice))
 
   call hipblasCheck(hipblasSaxpy(handle,n,alpha,dx,1,dy,1))
 
   call hipCheck(hipDeviceSynchronize())
 
-  call hipCheck(hipMemcpy(c_loc(y), dy, Nybytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(y(1)), dy, Nybytes, hipMemcpyDeviceToHost))
 
   do j = 1,n
     error = abs((y_exact(j) - y(j))/y_exact(j))

--- a/test/f2003/hipblas/scopy.f03
+++ b/test/f2003/hipblas/scopy.f03
@@ -42,14 +42,14 @@ program hip_scopy
   call hipCheck(hipMalloc(dx,Nxbytes))
   call hipCheck(hipMalloc(dy,Nybytes))
 
-  call hipCheck(hipMemcpy(dx, c_loc(x), Nxbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dy, c_loc(y), Nybytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(x(1)), Nxbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dy, c_loc(y(1)), Nybytes, hipMemcpyHostToDevice))
 
   call hipblasCheck(hipblasScopy(handle,n,dx,1,dy,1))
 
   call hipCheck(hipDeviceSynchronize())
 
-  call hipCheck(hipMemcpy(c_loc(y), dy, Nybytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(y(1)), dy, Nybytes, hipMemcpyDeviceToHost))
 
   do j = 0,n
     error = abs(y(j) - x(j))

--- a/test/f2003/hipblas/sgemv.f03
+++ b/test/f2003/hipblas/sgemv.f03
@@ -45,13 +45,13 @@ program hip_sgemv
   call hipCheck(hipMalloc(dy,Nybytes))
   call hipCheck(hipMalloc(da,Nabytes))
 
-  call hipCheck(hipMemcpy(da, c_loc(a), Nabytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dx, c_loc(x), Nxbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dy, c_loc(y), Nybytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(da, c_loc(a(1)), Nabytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(x(1)), Nxbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dy, c_loc(y(1)), Nybytes, hipMemcpyHostToDevice))
 
   call hipCheck(hipblasSgemv(handle,HIPBLAS_OP_N,m,n,alpha,da,m,dx,1,beta,dy,1))
 
-  call hipCheck(hipMemcpy(c_loc(y), dy, Nybytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(y(1)), dy, Nybytes, hipMemcpyDeviceToHost))
 
   do i = 1,m
     error = abs(5.0 - y(i))
@@ -74,4 +74,3 @@ program hip_sgemv
   write(*,*) "PASSED!"
 
 end program hip_sgemv
-

--- a/test/f2003/hipblas/sger.f03
+++ b/test/f2003/hipblas/sger.f03
@@ -60,16 +60,16 @@ program hip_sger
   !call hipCheck(hipblasSetVector(m,bytes_per_element,x,1,dx,1))
   !call hipCheck(hipblasSetVector(n,bytes_per_element,y,1,dy,1))
   
-  call hipCheck(hipMemcpy(da, c_loc(a), Nabytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dx, c_loc(x), Nxbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dy, c_loc(y), Nybytes, hipMemcpyHostToDevice)) 
+  call hipCheck(hipMemcpy(da, c_loc(a(1,1)), Nabytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(x(1)), Nxbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dy, c_loc(y(1)), Nybytes, hipMemcpyHostToDevice)) 
 
   call hipCheck(hipblasSger(handle,m,n,alpha,dx,1,dy,1,da,m))
   
   !call hipCheck(hipblasGetMatrix(m,n,bytes_per_element,da,m,a,m));
   call hipCheck(hipDeviceSynchronize())
 
-  call hipCheck(hipMemcpy(c_loc(a), da, Nabytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(a(1,1)), da, Nabytes, hipMemcpyDeviceToHost))
 
   !do i=1,m
   !  do j = 1,n

--- a/test/f2003/hipblas/sswap.f03
+++ b/test/f2003/hipblas/sswap.f03
@@ -40,13 +40,13 @@ program hip_sswap
   call hipCheck(hipMalloc(dx,Nxbytes))  
   call hipCheck(hipMalloc(dy,Nybytes))
   
-  call hipCheck(hipMemcpy(dx, c_loc(x), Nxbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(dy, c_loc(y), Nybytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(x(1)), Nxbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dy, c_loc(y(1)), Nybytes, hipMemcpyHostToDevice))
   
   call hipblasCheck(hipblasSswap(handle,n,dx,1,dy,1))
   
-  call hipCheck(hipMemcpy(c_loc(x), dx, Nxbytes, hipMemcpyDeviceToHost))
-  call hipCheck(hipMemcpy(c_loc(y), dy, Nybytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(x(1)), dx, Nxbytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(y(1)), dy, Nybytes, hipMemcpyDeviceToHost))
   
   do i = 1,n
     error = MAX(abs((y_exact(i) - x(i))/y_exact(i)), abs((x_exact(i) - y(i))/x_exact(i)))

--- a/test/f2003/hipfft/hipfft.f03
+++ b/test/f2003/hipfft/hipfft.f03
@@ -35,7 +35,7 @@ program hipfft_example
   hx(:)%y = -1
 
   call hipCheck(hipMalloc(dx, Nbytes))
-  call hipCheck(hipMemcpy(dx, c_loc(hx), Nbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx, c_loc(hx(1)), Nbytes, hipMemcpyHostToDevice))
 
   call hipfftCheck(hipfftPlan1d(plan, int(N, 4), HIPFFT_Z2Z, 1))
 
@@ -45,7 +45,7 @@ program hipfft_example
   call hipCheck(hipDeviceSynchronize())
 
 
-  call hipCheck(hipMemcpy(c_loc(hx),dx,Nbytes,hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hx(1)),dx,Nbytes,hipMemcpyDeviceToHost))
   call hipCheck(hipFree(dx))
 
   ! Using the C++ version of this as the "gold".

--- a/test/f2003/rocblas/saxpy.f03
+++ b/test/f2003/rocblas/saxpy.f03
@@ -73,8 +73,8 @@ program rocblas_saxpy_test
     end do
     
     ! Transfer data from host to deivce memory
-    call hipCheck(hipMemcpy(dx, c_loc(hx), Nbytes, hipMemcpyHostToDevice))
-    call hipCheck(hipmemcpy(dy, c_loc(hy), Nbytes, hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(dx, c_loc(hx(1)), Nbytes, hipMemcpyHostToDevice))
+    call hipCheck(hipmemcpy(dy, c_loc(hy(1)), Nbytes, hipMemcpyHostToDevice))
 
     ! Call rocblas function
     call rocblasCheck(rocblas_set_pointer_mode(rocblas_handle, 0))
@@ -82,7 +82,7 @@ program rocblas_saxpy_test
     call hipCheck(hipDeviceSynchronize())
 
     ! Transfer data back to host memory
-    call hipcheck(hipMemcpy(c_loc(hy), dy, Nbytes, hipMemcpyDeviceToHost))
+    call hipcheck(hipMemcpy(c_loc(hy(1)), dy, Nbytes, hipMemcpyDeviceToHost))
 
     ! Verification
     do i = 1, N

--- a/test/f2003/rocfft/rocfft.f03
+++ b/test/f2003/rocfft/rocfft.f03
@@ -35,14 +35,14 @@ program rocfft_example
   hx(:)%y = -1
 
   call hipCheck(hipMalloc(dx,Nbytes))
-  call hipCheck(hipMemcpy(dx,c_loc(hx),Nbytes,hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dx,c_loc(hx(1)),Nbytes,hipMemcpyHostToDevice))
 
   call rocfftCheck(rocfft_plan_create(plan,&
                                       rocfft_placement_inplace,&
                                       rocfft_transform_type_complex_forward,&
                                       rocfft_precision_double,&
                                       one,&
-                                      c_loc(lengths),&
+                                      c_loc(lengths(1)),&
                                       one,&
                                       c_null_ptr))
 
@@ -52,7 +52,7 @@ program rocfft_example
 
   call rocfftCheck(rocfft_plan_destroy(plan))
 
-  call hipCheck(hipMemcpy(c_loc(hx),dx,Nbytes,hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hx(1)),dx,Nbytes,hipMemcpyDeviceToHost))
   call hipCheck(hipFree(dx))
 
   ! Using the C++ version of this as the "gold".

--- a/test/f2003/rocsolver/rocsolver_dgeqrf.f03
+++ b/test/f2003/rocsolver/rocsolver_dgeqrf.f03
@@ -45,14 +45,14 @@ program dgeqrf
   call hipCheck(rocblas_create_handle(handle))
 
   ! Copy memory from host to device
-  call hipCheck(hipMemcpy(dA, c_loc(hA), size_A * 8, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(dA, c_loc(hA(1,1)), size_A * 8, hipMemcpyHostToDevice))
 
   ! Compute the QR factorization on the devi ce
   call hipCheck(rocsolver_dgeqrf(handle, M, N, dA, lda, dIpiv))
 
   ! Copy result from device to host
-  call hipCheck(hipMemcpy(c_loc(hA), dA, size_A * 8, hipMemcpyDeviceToHost))
-  call hipCheck(hipMemcpy(c_loc(hIpiv), dIpiv, size_Ipiv * 8, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hA(1,1)), dA, size_A * 8, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hIpiv(1)), dIpiv, size_Ipiv * 8, hipMemcpyDeviceToHost))
 
   ! Output results
   do j = 1,size(hA,2)

--- a/test/f2003/rocsparse/ddoti.f03
+++ b/test/f2003/rocsparse/ddoti.f03
@@ -66,9 +66,9 @@ program rocsparse_ddoti_test
     call hipCheck(hipMalloc(d_dot, int(8, c_size_t)))
 
 !   Copy host data to device
-    call hipCheck(hipMemcpy(d_xind, c_loc(h_xind), (int(nnz, c_size_t) + 1) * 4, hipMemcpyHostToDevice))
-    call hipCheck(hipMemcpy(d_xval, c_loc(h_xval), int(nnz, c_size_t) * 8, hipMemcpyHostToDevice))
-    call hipCheck(hipMemcpy(d_y, c_loc(h_y), int(M, c_size_t) * 8, hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(d_xind, c_loc(h_xind(1)), (int(nnz, c_size_t) + 1) * 4, hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(d_xval, c_loc(h_xval(1)), int(nnz, c_size_t) * 8, hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(d_y, c_loc(h_y(1)), int(M, c_size_t) * 8, hipMemcpyHostToDevice))
 
 !   Create rocSPARSE handle
     call rocsparseCheck(rocsparse_create_handle(handle))

--- a/test/f2003/vecadd/main.f03
+++ b/test/f2003/vecadd/main.f03
@@ -46,15 +46,15 @@ program fortran_hip
   call hipCheck(hipMalloc(dout,Nbytes))
 
   ! Transfer data from host to device memory
-  call hipCheck(hipMemcpy(da, c_loc(a), Nbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(db, c_loc(b), Nbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(da, c_loc(a(1)), Nbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(db, c_loc(b(1)), Nbytes, hipMemcpyHostToDevice))
 
   call launch(dout,da,db,N)
 
   call hipCheck(hipDeviceSynchronize())
 
   ! Transfer data back to host memory
-  call hipCheck(hipMemcpy(c_loc(out), dout, Nbytes, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(out(1)), dout, Nbytes, hipMemcpyDeviceToHost))
 
   ! Verification
   do i = 1,N


### PR DESCRIPTION
* Issue was only observed on CentOS 7.7 with
  gfortran 7.3.1-5.
* In this config, gfortran seems not to accept
  that you pass non-scalar variables to c_loc intrinsic
* Change f2003 tests to satisfy this requirement