### PR TITLE
ROCm package file/folder reorganization(SWDEV-291455)

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -50,12 +50,12 @@ install(PROGRAMS
    # These two have their version string edited
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/mymcpu
-   DESTINATION bin
+   DESTINATION bin/hipfort
    ${RUNTIME_COMPONENT}
 )
 
 install(FILES
    ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/Makefile.hipfort
-   DESTINATION bin
+   DESTINATION bin/hipfort
    ${RUNTIME_COMPONENT})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB HIPFORT_SRC_CONTRIB "${CMAKE_CURRENT_SOURCE_DIR}/modules-contrib/*.f*"
 set(HIPFORT_ARCH "amdgcn")
     # amdgcn
     set(HIPFORT_LIB      "hipfort-${HIPFORT_ARCH}")
-    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${HIPFORT_ARCH})
+    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
     ADD_LIBRARY(${HIPFORT_LIB} STATIC 
         ${HIPFORT_SRC_HIP} 
         #${HIPFORT_SRC_amdgcn} 
@@ -26,7 +26,7 @@ set(HIPFORT_ARCH "amdgcn")
 set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
-    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${HIPFORT_ARCH})
+    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
     ADD_LIBRARY(${HIPFORT_LIB} STATIC 
          ${HIPFORT_SRC_HIP} 
          #${HIPFORT_SRC_nvptx} 
@@ -42,7 +42,7 @@ set(HIPFORT_ARCH "nvptx")
             LIBRARY DESTINATION lib
             ${DEVEL_COMPONENT})
    
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include DESTINATION . ${DEVEL_COMPONENT})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort DESTINATION include ${DEVEL_COMPONENT})
 
 #   target_link_libraries(${HIPFORT_LIB} PUBLIC 
 #   /usr/local/cuda/targets/x86_64-linux/lib/libcudart_static.a)


### PR DESCRIPTION
Summary of proposed changes:
	- Package file/folder reorg applied for lib (rocmpath/lib) (removed component name prefix)
	- Package file/folder reorg applied for include (rocmpath/include/<compnm>)
	- Package file/folder reorg applied for bin (rocmpath/bin)
	- Package file/folder reorg applied for extra binaries/files in bin mymcpu, Makefile.hipfort (rocmpath/bin/<compn>)