### PR TITLE
BUGFIX: For fptr ifaces FC must support c_loc(<assumed-shape array>)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,10 @@ IF(NOT DEFINED CMAKE_Fortran_COMPILER_SUPPORTS_F08)
       end interface
     contains
       subroutine foo_a(a)
+        use iso_c_binding
         integer,target,dimension(:) :: a
+        type(c_ptr) :: a_ptr
+        a_ptr = c_loc(a) ! gfortran < 4.9 fails here
       end
       subroutine foo_b(b)
         integer,pointer,dimension(:,:) :: b


### PR DESCRIPTION
* Add additional test to main CMakeLists.txt that
gfortran < 4.9 is supposed to fail.
* Expression (`c_loc(<assumed-shape array var>)`) that gfortran < 4.9 fails to compile
appears in HIPFORT's Fortran pointer interfaces. It is essential.