### PR TITLE
File/Folder Reorg Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/ROCmSoftwarePlatform/hipfort
 mkdir build ; cd build
 cmake -DHIPFORT_INSTALL_DIR=/tmp/hipfort ..
 make install
-export PATH=/tmp/hipfort/bin:$PATH
+export PATH=/tmp/hipfort/libexec/hipfort:$PATH
 cd ../test/f2003/vecadd
 hipfc -v hip_implementation.cpp main.f03
 ./a.out

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ https://rocmsoftwareplatform.github.io/hipfort/index.html
 ## hipfc wrapper compiler and Makefile.hipfort
 
 Aside from Fortran interfaces to the HIP and ROCm libraries, hipfort ships the `hipfc` wrapper compiler
-and a `Makefile.hipfort` that can be included into a project's build system. Both are located in the `bin/` subdirectory
-of the repository. While both can be configured via a number of environment variables, `hipfc` also understands a greater number of 
-command line options that you can print to screen via `hipfc -h`. 
+and a `Makefile.hipfort` that can be included into a project's build system. hipfc located in the `bin/` subdirectory and
+Makefile.hipfort in share/hipfort of the repository. While both can be configured via a number of environment variables,`
+hipfc` also understands a greater number of command line options that you can print to screen via `hipfc -h`.
 
 Among the environment variables, the most important are:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/ROCmSoftwarePlatform/hipfort
 mkdir build ; cd build
 cmake -DHIPFORT_INSTALL_DIR=/tmp/hipfort ..
 make install
-export PATH=/tmp/hipfort/libexec/hipfort:$PATH
+export PATH=/tmp/hipfort/bin:$PATH
 cd ../test/f2003/vecadd
 hipfc -v hip_implementation.cpp main.f03
 ./a.out

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -5,38 +5,42 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 # ensure mymcpu utility and Makefile.hipfort are available in build directory 
-add_custom_command( OUTPUT bindir
+add_custom_command( OUTPUT sharedir
+   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort)
+
+add_custom_command( OUTPUT libexecdir
    COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt)
 
-add_custom_command( OUTPUT sharedir
-   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort
-   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt)
+add_custom_command( OUTPUT bindir
+   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../bin
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipfc)
 
-add_custom_command( OUTPUT ../libexec/hipfort/gputable.txt
+add_custom_command( OUTPUT gputable.txt
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/gputable.txt
-   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt bindir)
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt libexecdir)
 
 string(REGEX REPLACE "[/]" "\\\\/" escaped_path ${HIPFORT_COMPILER})
 set(sed_str s/gfortran/${escaped_path}/g)
 string(REGEX REPLACE "[/]" "\\\\/" installed_path ${HIPFORT_INSTALL_DIR})
 set(sed_str2 s/_HIPFORT_INSTALL_DIR_/${installed_path}/g)
 
-add_custom_command( OUTPUT ../share/hipfort/Makefile.hipfort
+add_custom_command( OUTPUT Makefile.hipfort
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit
    COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit > ../share/hipfort/Makefile.hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort sharedir)
 
-add_custom_command( OUTPUT ../libexec/hipfort/mymcpu
+add_custom_command( OUTPUT mymcpu
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu.needs_edit
    COMMAND /bin/sed -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu.needs_edit > ../libexec/hipfort/mymcpu
    COMMAND /bin/chmod  755  ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu
-   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu bindir)
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu libexecdir)
 
 # The myarchgpu symbolic link is needed for test targets before installation
-add_custom_command( OUTPUT ../libexec/hipfort/myarchgpu
-   COMMAND /bin/ln -sf ../libexec/hipfort/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/myarchgpu
-   DEPENDS ../libexec/hipfort/mymcpu)
+add_custom_command( OUTPUT myarchgpu
+   COMMAND /bin/ln -sf ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/myarchgpu
+   DEPENDS mymcpu libexecdir)
 
 add_custom_command( OUTPUT hipfc
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
@@ -46,26 +50,29 @@ add_custom_command( OUTPUT hipfc
    COMMAND /bin/chmod 755 hipfc
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipfc bindir)
 
-add_custom_target(util_scripts ALL DEPENDS bindir ../libexec/hipfort/gputable.txt ../share/hipfort/Makefile.hipfort hipfc ../libexec/hipfort/mymcpu ../libexec/hipfort/myarchgpu)
+add_custom_target(util_scripts ALL DEPENDS bindir libexecdir sharedir gputable.txt Makefile.hipfort hipfc mymcpu myarchgpu)
 
-#HIPFC Install
 install(PROGRAMS
-   # With version string edited
+   # Version string edited
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc
    DESTINATION bin
 )
 
-#Other binaries install
 install(PROGRAMS
    # The first two are symlinks
    ${CMAKE_CURRENT_SOURCE_DIR}/mygpu
    ${CMAKE_CURRENT_SOURCE_DIR}/myarchgpu
-   ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
-   # With version string edited
+   # Version string edited
    ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu
    DESTINATION libexec/hipfort
 )
 
+#GPUTable.txt installed to libexec 
+install(FILES
+   ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
+   DESTINATION libexec/hipfort)
+
+#Makefile.hipfort installed to share
 install(FILES
    ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort
    DESTINATION share/hipfort)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -31,8 +31,8 @@ add_custom_command( OUTPUT hipfort/mymcpu
 
 # The myarchgpu symbolic link is needed for test targets before installation
 add_custom_command( OUTPUT hipfort/myarchgpu
-   COMMAND /bin/ln -sf mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/myarchgpu
-   DEPENDS mymcpu)
+   COMMAND /bin/ln -sf hipfort/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/myarchgpu
+   DEPENDS hipfort/mymcpu)
 
 add_custom_command( OUTPUT hipfort/hipfc
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -50,10 +50,10 @@ install(PROGRAMS
    # These two have their version string edited
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/mymcpu
-   DESTINATION bin
+   DESTINATION bin/hipfort
 )
 
 install(FILES
    ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
    ${CMAKE_CURRENT_BINARY_DIR}/../bin/Makefile.hipfort
-   DESTINATION bin)
+   DESTINATION bin/hipfort)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -6,10 +6,11 @@ endif()
 
 # ensure mymcpu utility and Makefile.hipfort are available in build directory 
 add_custom_command( OUTPUT bindir
-   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../bin
+   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt)
-add_custom_command( OUTPUT gputable.txt
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../bin/gputable.txt
+
+add_custom_command( OUTPUT hipfort/gputable.txt
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/gputable.txt
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt bindir)
 
 string(REGEX REPLACE "[/]" "\\\\/" escaped_path ${HIPFORT_COMPILER})
@@ -17,43 +18,43 @@ set(sed_str s/gfortran/${escaped_path}/g)
 string(REGEX REPLACE "[/]" "\\\\/" installed_path ${HIPFORT_INSTALL_DIR})
 set(sed_str2 s/_HIPFORT_INSTALL_DIR_/${installed_path}/g)
 
-add_custom_command( OUTPUT Makefile.hipfort
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../bin/Makefile.hipfort.needs_edit
-   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/Makefile.hipfort.needs_edit > Makefile.hipfort
+add_custom_command( OUTPUT hipfort/Makefile.hipfort
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/Makefile.hipfort.needs_edit
+   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/Makefile.hipfort.needs_edit > hipfort/Makefile.hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort bindir)
 
-add_custom_command( OUTPUT mymcpu
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/mymcpu.needs_edit
-   COMMAND /bin/sed -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/mymcpu.needs_edit >mymcpu
-   COMMAND /bin/chmod  755  ${CMAKE_CURRENT_BINARY_DIR}/../bin/mymcpu
+add_custom_command( OUTPUT hipfort/mymcpu
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu.needs_edit
+   COMMAND /bin/sed -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu.needs_edit >hipfort/mymcpu
+   COMMAND /bin/chmod  755  ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu bindir)
 
 # The myarchgpu symbolic link is needed for test targets before installation
-add_custom_command( OUTPUT myarchgpu
-   COMMAND /bin/ln -sf mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/myarchgpu
+add_custom_command( OUTPUT hipfort/myarchgpu
+   COMMAND /bin/ln -sf mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/myarchgpu
    DEPENDS mymcpu)
 
-add_custom_command( OUTPUT hipfc
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
-   COMMAND /bin/sed -i -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
-   COMMAND /bin/sed -i -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
-   COMMAND /bin/sed -e '${sed_str2}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit > hipfc
-   COMMAND /bin/chmod 755 hipfc
+add_custom_command( OUTPUT hipfort/hipfc
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit
+   COMMAND /bin/sed -i -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit
+   COMMAND /bin/sed -i -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit
+   COMMAND /bin/sed -e '${sed_str2}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit > hipfort/hipfc
+   COMMAND /bin/chmod 755 hipfort/hipfc
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipfc bindir)
 
-add_custom_target(util_scripts ALL DEPENDS bindir gputable.txt Makefile.hipfort hipfc mymcpu myarchgpu)
+add_custom_target(util_scripts ALL DEPENDS bindir hipfort/gputable.txt hipfort/Makefile.hipfort hipfort/hipfc hipfort/mymcpu hipfort/myarchgpu)
 
 install(PROGRAMS
    # The first two are symlinks
    ${CMAKE_CURRENT_SOURCE_DIR}/mygpu
    ${CMAKE_CURRENT_SOURCE_DIR}/myarchgpu
    # These two have their version string edited
-   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc
-   ${CMAKE_CURRENT_BINARY_DIR}/../bin/mymcpu
+   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc
+   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu
    DESTINATION bin/hipfort
 )
 
 install(FILES
    ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
-   ${CMAKE_CURRENT_BINARY_DIR}/../bin/Makefile.hipfort
+   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/Makefile.hipfort
    DESTINATION bin/hipfort)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -6,11 +6,11 @@ endif()
 
 # ensure mymcpu utility and Makefile.hipfort are available in build directory 
 add_custom_command( OUTPUT bindir
-   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort
+   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt)
 
-add_custom_command( OUTPUT hipfort/gputable.txt
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/gputable.txt
+add_custom_command( OUTPUT ../libexec/hipfort/gputable.txt
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/gputable.txt
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt bindir)
 
 string(REGEX REPLACE "[/]" "\\\\/" escaped_path ${HIPFORT_COMPILER})
@@ -18,43 +18,43 @@ set(sed_str s/gfortran/${escaped_path}/g)
 string(REGEX REPLACE "[/]" "\\\\/" installed_path ${HIPFORT_INSTALL_DIR})
 set(sed_str2 s/_HIPFORT_INSTALL_DIR_/${installed_path}/g)
 
-add_custom_command( OUTPUT hipfort/Makefile.hipfort
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/Makefile.hipfort.needs_edit
-   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/Makefile.hipfort.needs_edit > hipfort/Makefile.hipfort
+add_custom_command( OUTPUT ../libexec/hipfort/Makefile.hipfort
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/Makefile.hipfort.needs_edit
+   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/Makefile.hipfort.needs_edit > ../libexec/hipfort/Makefile.hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort bindir)
 
-add_custom_command( OUTPUT hipfort/mymcpu
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu.needs_edit
-   COMMAND /bin/sed -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu.needs_edit >hipfort/mymcpu
-   COMMAND /bin/chmod  755  ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu
+add_custom_command( OUTPUT ../libexec/hipfort/mymcpu
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu.needs_edit
+   COMMAND /bin/sed -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu.needs_edit > ../libexec/hipfort/mymcpu
+   COMMAND /bin/chmod  755  ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu bindir)
 
 # The myarchgpu symbolic link is needed for test targets before installation
-add_custom_command( OUTPUT hipfort/myarchgpu
-   COMMAND /bin/ln -sf hipfort/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/myarchgpu
-   DEPENDS hipfort/mymcpu)
+add_custom_command( OUTPUT ../libexec/hipfort/myarchgpu
+   COMMAND /bin/ln -sf ../libexec/hipfort/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/myarchgpu
+   DEPENDS ../libexec/hipfort/mymcpu)
 
-add_custom_command( OUTPUT hipfort/hipfc
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit
-   COMMAND /bin/sed -i -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit
-   COMMAND /bin/sed -i -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit
-   COMMAND /bin/sed -e '${sed_str2}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc.needs_edit > hipfort/hipfc
-   COMMAND /bin/chmod 755 hipfort/hipfc
+add_custom_command( OUTPUT ../libexec/hipfort/hipfc
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit
+   COMMAND /bin/sed -i -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit
+   COMMAND /bin/sed -i -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit
+   COMMAND /bin/sed -e '${sed_str2}' ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit > ../libexec/hipfort/hipfc
+   COMMAND /bin/chmod 755 ../libexec/hipfort/hipfc
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipfc bindir)
 
-add_custom_target(util_scripts ALL DEPENDS bindir hipfort/gputable.txt hipfort/Makefile.hipfort hipfort/hipfc hipfort/mymcpu hipfort/myarchgpu)
+add_custom_target(util_scripts ALL DEPENDS bindir ../libexec/hipfort/gputable.txt ../libexec/hipfort/Makefile.hipfort ../libexec/hipfort/hipfc ../libexec/hipfort/mymcpu ../libexec/hipfort/myarchgpu)
 
 install(PROGRAMS
    # The first two are symlinks
    ${CMAKE_CURRENT_SOURCE_DIR}/mygpu
    ${CMAKE_CURRENT_SOURCE_DIR}/myarchgpu
    # These two have their version string edited
-   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/hipfc
-   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/mymcpu
-   DESTINATION bin/hipfort
+   ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc
+   ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu
+   DESTINATION libexec/hipfort
 )
 
 install(FILES
    ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
-   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfort/Makefile.hipfort
-   DESTINATION bin/hipfort)
+   ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/Makefile.hipfort
+   DESTINATION libexec/hipfort)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -9,6 +9,10 @@ add_custom_command( OUTPUT bindir
    COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt)
 
+add_custom_command( OUTPUT sharedir
+   COMMAND /bin/mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt)
+
 add_custom_command( OUTPUT ../libexec/hipfort/gputable.txt
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/gputable.txt
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt bindir)
@@ -18,10 +22,10 @@ set(sed_str s/gfortran/${escaped_path}/g)
 string(REGEX REPLACE "[/]" "\\\\/" installed_path ${HIPFORT_INSTALL_DIR})
 set(sed_str2 s/_HIPFORT_INSTALL_DIR_/${installed_path}/g)
 
-add_custom_command( OUTPUT ../libexec/hipfort/Makefile.hipfort
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/Makefile.hipfort.needs_edit
-   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/Makefile.hipfort.needs_edit > ../libexec/hipfort/Makefile.hipfort
-   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort bindir)
+add_custom_command( OUTPUT ../share/hipfort/Makefile.hipfort
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit
+   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit > ../share/hipfort/Makefile.hipfort
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort sharedir)
 
 add_custom_command( OUTPUT ../libexec/hipfort/mymcpu
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu.needs_edit
@@ -42,7 +46,7 @@ add_custom_command( OUTPUT hipfc
    COMMAND /bin/chmod 755 hipfc
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipfc bindir)
 
-add_custom_target(util_scripts ALL DEPENDS bindir ../libexec/hipfort/gputable.txt ../libexec/hipfort/Makefile.hipfort hipfc ../libexec/hipfort/mymcpu ../libexec/hipfort/myarchgpu)
+add_custom_target(util_scripts ALL DEPENDS bindir ../libexec/hipfort/gputable.txt ../share/hipfort/Makefile.hipfort hipfc ../libexec/hipfort/mymcpu ../libexec/hipfort/myarchgpu)
 
 #HIPFC Install
 install(PROGRAMS
@@ -56,12 +60,12 @@ install(PROGRAMS
    # The first two are symlinks
    ${CMAKE_CURRENT_SOURCE_DIR}/mygpu
    ${CMAKE_CURRENT_SOURCE_DIR}/myarchgpu
+   ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
    # With version string edited
    ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu
    DESTINATION libexec/hipfort
 )
 
 install(FILES
-   ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt
-   ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/Makefile.hipfort
-   DESTINATION libexec/hipfort)
+   ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort
+   DESTINATION share/hipfort)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -34,22 +34,29 @@ add_custom_command( OUTPUT ../libexec/hipfort/myarchgpu
    COMMAND /bin/ln -sf ../libexec/hipfort/mymcpu ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/myarchgpu
    DEPENDS ../libexec/hipfort/mymcpu)
 
-add_custom_command( OUTPUT ../libexec/hipfort/hipfc
-   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit
-   COMMAND /bin/sed -i -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit
-   COMMAND /bin/sed -i -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit
-   COMMAND /bin/sed -e '${sed_str2}' ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc.needs_edit > ../libexec/hipfort/hipfc
-   COMMAND /bin/chmod 755 ../libexec/hipfort/hipfc
+add_custom_command( OUTPUT hipfc
+   COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/hipfc ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
+   COMMAND /bin/sed -i -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
+   COMMAND /bin/sed -i -e "s/X\\.Y\\-Z/${HIPFORT_VERSION}/g" ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit
+   COMMAND /bin/sed -e '${sed_str2}' ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc.needs_edit > hipfc
+   COMMAND /bin/chmod 755 hipfc
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipfc bindir)
 
-add_custom_target(util_scripts ALL DEPENDS bindir ../libexec/hipfort/gputable.txt ../libexec/hipfort/Makefile.hipfort ../libexec/hipfort/hipfc ../libexec/hipfort/mymcpu ../libexec/hipfort/myarchgpu)
+add_custom_target(util_scripts ALL DEPENDS bindir ../libexec/hipfort/gputable.txt ../libexec/hipfort/Makefile.hipfort hipfc ../libexec/hipfort/mymcpu ../libexec/hipfort/myarchgpu)
 
+#HIPFC Install
+install(PROGRAMS
+   # With version string edited
+   ${CMAKE_CURRENT_BINARY_DIR}/../bin/hipfc
+   DESTINATION bin
+)
+
+#Other binaries install
 install(PROGRAMS
    # The first two are symlinks
    ${CMAKE_CURRENT_SOURCE_DIR}/mygpu
    ${CMAKE_CURRENT_SOURCE_DIR}/myarchgpu
-   # These two have their version string edited
-   ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/hipfc
+   # With version string edited
    ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/mymcpu
    DESTINATION libexec/hipfort
 )

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -7,7 +7,7 @@
 # set HIPFORT_HOME to the build or install location of HIPFORT.  For example:
 #
 #    HIPFORT_HOME ?= /opt/rocm/
-#    include $(HIPFORT_HOME)/libexec/hipfort/Makefile.hipfort
+#    include $(HIPFORT_HOME)/share/hipfort/Makefile.hipfort
 #  
 # If the caller does not set HIPFORT_ARCHGPU, this Makefile will call 
 # a self-identification utility called myarchgpu.  Please create an issue

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -18,7 +18,7 @@
 #    HIPFORT_ARCHGPU = nvptx-sm_70
 #
 
-HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/myarchgpu)
+HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/hipfort/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
 HIPFORT_COMPILER ?= gfortran
 CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
@@ -27,7 +27,7 @@ DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
 HIP_CLANG_PATH   ?= $(ROCM_PATH)/llvm/bin
 HIP_PLATFORM=${HIP_PLATFORM:-amd}
 
-MOD_DIR  = $(HIPFORT_HOME)/include/$(ARCH)
+MOD_DIR  = $(HIPFORT_HOME)/include/hipfort/$(ARCH)
 LIB_DIR  = $(HIPFORT_HOME)/lib
 
 GPU = $(strip $(subst ., ,$(suffix $(subst -,.,$(HIPFORT_ARCHGPU)))))

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -6,8 +6,8 @@
 # This file is meant to be included by other Makefiles.  The includer must 
 # set HIPFORT_HOME to the build or install location of HIPFORT.  For example:
 #
-#    HIPFORT_HOME ?= /opt/rocm/hipfort
-#    include $(HIPFORT_HOME)/bin/Makefile.hipfort
+#    HIPFORT_HOME ?= /opt/rocm/
+#    include $(HIPFORT_HOME)/bin/hipfort/Makefile.hipfort
 #  
 # If the caller does not set HIPFORT_ARCHGPU, this Makefile will call 
 # a self-identification utility called myarchgpu.  Please create an issue
@@ -18,7 +18,7 @@
 #    HIPFORT_ARCHGPU = nvptx-sm_70
 #
 
-HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/bin/hipfort/myarchgpu)
+HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/libexec/hipfort/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
 HIPFORT_COMPILER ?= gfortran
 CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}

--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -7,7 +7,7 @@
 # set HIPFORT_HOME to the build or install location of HIPFORT.  For example:
 #
 #    HIPFORT_HOME ?= /opt/rocm/
-#    include $(HIPFORT_HOME)/bin/hipfort/Makefile.hipfort
+#    include $(HIPFORT_HOME)/libexec/hipfort/Makefile.hipfort
 #  
 # If the caller does not set HIPFORT_ARCHGPU, this Makefile will call 
 # a self-identification utility called myarchgpu.  Please create an issue

--- a/bin/hipfc
+++ b/bin/hipfc
@@ -286,7 +286,7 @@ fi
 # Determine which gfx processor to use, default to Vega (gfx900)
 if [ ! $HIPFORT_GPU ] ; then 
    # Use the mygpu in pair with this script, no the pre-installed one.
-   HIPFORT_GPU=`$cdir/mygpu -d gfx900`
+   HIPFORT_GPU=`$cdir/../libexec/hipfort/mygpu -d gfx900`
    if [ "$HIPFORT_GPU" == "" ] ; then 
       HIPFORT_GPU="gfx900"
    fi

--- a/bin/hipfc
+++ b/bin/hipfc
@@ -398,9 +398,9 @@ if [ "$UNAMEP" == "ppc64le" ] ; then
 fi
 
 if [[ "$HIPFORT_COMPILER" == *"ftn" ]] ; then
-  FCARGS="-eT -J$HIPFORT/include/$TARGET_ARCH"
+  FCARGS="-eT -J$HIPFORT/include/hipfort/$TARGET_ARCH"
 else
-  FCARGS="-cpp -I$HIPFORT/include/$TARGET_ARCH"
+  FCARGS="-cpp -I$HIPFORT/include/hipfort/$TARGET_ARCH"
 fi
 
 if [ $GEN_OBJECT_ONLY ]  ; then 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -42,7 +42,7 @@ set(HIPFORT_ARCH "nvptx")
             ARCHIVE DESTINATION lib
             LIBRARY DESTINATION lib)
    
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort DESTINATION .)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort DESTINATION include)
 
 #   target_link_libraries(${HIPFORT_LIB} PUBLIC 
 #   /usr/local/cuda/targets/x86_64-linux/lib/libcudart_static.a)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB HIPFORT_SRC_CONTRIB "${CMAKE_CURRENT_SOURCE_DIR}/modules-contrib/*.f*"
 set(HIPFORT_ARCH "amdgcn")
     # amdgcn
     set(HIPFORT_LIB      "hipfort-${HIPFORT_ARCH}")
-    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${HIPFORT_ARCH})
+    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
     ADD_LIBRARY(${HIPFORT_LIB} STATIC 
         ${HIPFORT_SRC_HIP} 
         #${HIPFORT_SRC_amdgcn} 
@@ -27,7 +27,7 @@ set(HIPFORT_ARCH "amdgcn")
 set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
-    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/${HIPFORT_ARCH})
+    set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
     ADD_LIBRARY(${HIPFORT_LIB} STATIC 
          ${HIPFORT_SRC_HIP} 
          #${HIPFORT_SRC_nvptx} 
@@ -42,7 +42,7 @@ set(HIPFORT_ARCH "nvptx")
             ARCHIVE DESTINATION lib
             LIBRARY DESTINATION lib)
    
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include DESTINATION .)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort DESTINATION .)
 
 #   target_link_libraries(${HIPFORT_LIB} PUBLIC 
 #   /usr/local/cuda/targets/x86_64-linux/lib/libcudart_static.a)


### PR DESCRIPTION
**File/Folder Reorg Changes Updated**

1. include folder update to include/<component name>/ structure. ex: The files under include folders (__include/<HIPFORT_ARCH>___  moved to (__include/hipfort/<HIPFORT_ARCH>_)
2. Component Private Binary Files moved to libexec/<component name>. ex: Files _gputable.txt, myarchgpu, mygpu, mymcpu_ in bin moved to _libexec/hipfort_
3. Misc Files/Samples moved to share/<component name>. ex: _Makefile.hipfort_ moved to _share/hipfort_
4. _Makefile.hipfort_ and _hipfc_ updated with new include and binary file paths.

**New Structure - Snapshot**

opt
└── rocm
    ├── bin
    │   └── hipfc
    ├── include
    │   └── hipfort
    │       ├── amdgcn
    │       │   ├── hipfort_auxiliary.mod
    │       │   ├── ....
    │       └── nvptx
    │           ├── hipfort_auxiliary.mod
    │           ├── ....
    ├── lib
    │   ├── libhipfort-amdgcn.a
    │   └── libhipfort-nvptx.a
    ├── libexec
    │   └── hipfort
    │       ├── gputable.txt
    │       ├── myarchgpu -> mymcpu
    │       ├── mygpu -> mymcpu
    │       └── mymcpu
    └── share
        ├── doc
        │   └── hipfort
        │       └── LICENSE
        └── hipfort
            └── Makefile.hipfort
