### PR TITLE
Export hipfort CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ message("-- HIPFORT_VERSION:        ${HIPFORT_VERSION}")
 message("-- HIPFORT ----------------------------------------------")
 
 set(CMAKE_Fortran_COMPILER_INIT ${HIPFORT_COMPILER})
-PROJECT(hipfort Fortran C)
+PROJECT(hipfort Fortran C CXX) # hip-config.cmake requires CXX enabled
 
 SET(CMAKE_BUILD_TYPE ${HIPFORT_BUILD_TYPE})
 SET(VERSION ${HIPFORT_VERSION})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,22 @@
+# Copyright (c) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 IF(NOT CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-underscoring")
@@ -16,6 +35,10 @@ set(HIPFORT_ARCH "amdgcn")
         #${HIPFORT_SRC_amdgcn} 
         ${HIPFORT_SRC_CONTRIB} 
         )
+    target_include_directories(${HIPFORT_LIB}
+      PUBLIC
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hipfort/amdgcn>
+    )
     IF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
     	target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_FPOINTER_INTERFACES)
     ENDIF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
@@ -55,3 +78,160 @@ set(HIPFORT_ARCH "nvptx")
 
 #   target_link_libraries(${HIPFORT_LIB} PUBLIC 
 #   /usr/local/cuda/targets/x86_64-linux/lib/libcudart_static.a)
+
+install(
+  TARGETS
+    hipfort-amdgcn
+  EXPORT hipfort-amdgcn-targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  EXPORT hipfort-amdgcn-targets
+  FILE hipfort-amdgcn-targets.cmake
+  NAMESPACE hipfort::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
+)
+
+macro(hipfort_add_component name imported_target)
+  add_library(hipfort-${name} INTERFACE)
+  add_library(hipfort::${name} ALIAS hipfort-${name})
+  set_target_properties(hipfort-${name}
+    PROPERTIES
+      EXPORT_NAME ${name}
+  )
+  target_link_libraries(hipfort-${name} INTERFACE hipfort-amdgcn ${imported_target})
+  install(
+    TARGETS
+      hipfort-${name}
+    EXPORT hipfort-${name}-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+  install(
+    EXPORT hipfort-${name}-targets
+    FILE hipfort-${name}-targets.cmake
+    NAMESPACE hipfort::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
+  )
+endmacro()
+
+find_package(hip)
+if(hip_FOUND)
+  add_library(hipfort-host INTERFACE)
+  add_library(hipfort::host ALIAS hipfort-host)
+  target_link_libraries(hipfort-host INTERFACE hipfort-amdgcn hip::host)
+  install(
+    TARGETS
+      hipfort-host
+    EXPORT hipfort-hip-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+  install(
+    EXPORT hipfort-hip-targets
+    FILE hipfort-hip-targets.cmake
+    NAMESPACE hipfort::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
+  )
+else()
+  message(STATUS "Skipping hipfort::host target export")
+endif()
+
+find_package(rocblas)
+if(rocblas_FOUND)
+  hipfort_add_component(rocblas roc::rocblas)
+else()
+  message(STATUS "Skipping hipfort::rocblas target export")
+endif()
+
+find_package(hipblas)
+if(hipblas_FOUND)
+  hipfort_add_component(hipblas roc::hipblas)
+else()
+  message(STATUS "Skipping hipfort::hipblas target export")
+endif()
+
+find_package(rocfft)
+if(rocfft_FOUND)
+  hipfort_add_component(rocfft roc::rocfft)
+else()
+  message(STATUS "Skipping hipfort::rocfft target export")
+endif()
+
+find_package(hipfft)
+if(hipfft_FOUND)
+  hipfort_add_component(hipfft hip::hipfft)
+else()
+  message(STATUS "Skipping hipfort::hipfft target export")
+endif()
+
+find_package(rocrand)
+if(rocrand_FOUND)
+  hipfort_add_component(rocrand roc::rocrand)
+else()
+  message(STATUS "Skipping hipfort::rocrand target export")
+endif()
+
+find_package(hiprand)
+if(hiprand_FOUND)
+  hipfort_add_component(hiprand hip::hiprand)
+else()
+  message(STATUS "Skipping hipfort::hiprand target export")
+endif()
+
+find_package(rocsolver)
+if(rocsolver_FOUND)
+  hipfort_add_component(rocsolver roc::rocsolver)
+else()
+  message(STATUS "Skipping hipfort::rocsolver target export")
+endif()
+
+find_package(hipsolver)
+if(hipsolver_FOUND)
+  hipfort_add_component(hipsolver roc::hipsolver)
+else()
+  message(STATUS "Skipping hipfort::hipsolver target export")
+endif()
+
+find_package(rocsparse)
+if(rocsparse_FOUND)
+  hipfort_add_component(rocsparse roc::rocsparse)
+else()
+  message(STATUS "Skipping hipfort::rocsparse target export")
+endif()
+
+find_package(hipsparse)
+if(hipsparse_FOUND)
+  hipfort_add_component(hipsparse hip::hipsparse)
+else()
+  message(STATUS "Skipping hipfort::hipsparse target export")
+endif()
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  hipfort-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config-version.cmake
+  VERSION "${HIPFORT_VERSION_MAJOR}.${HIPFORT_VERSION_MINOR}.${HIPFORT_VERSION_PATCH}"
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config-version.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
+)

--- a/lib/hipfort-config.cmake.in
+++ b/lib/hipfort-config.cmake.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+set(_hipfort_supported_components hip
+  rocblas rocfft rocrand rocsolver rocsparse
+  hipblas hipfft hiprand hipsolver hipsparse)
+
+include("${CMAKE_CURRENT_LIST_DIR}/hipfort-amdgcn-targets.cmake")
+foreach(_comp ${hipfort_FIND_COMPONENTS})
+  if (NOT _comp IN_LIST _hipfort_supported_components)
+    set(hipfort_FOUND False)
+    set(hipfort_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+  endif()
+  include("${CMAKE_CURRENT_LIST_DIR}/hipfort-${_comp}-targets.cmake")
+  find_dependency(${_comp})
+endforeach()


### PR DESCRIPTION
If the ROCm math libraries are available at configuration-time, the hipfort project will generate CMake targets for their fortran bindings. To use the hipfort bindings, use

    find_package(hipfort COMPONENTS <libraries>)

where <libraries> is a space-delimited list of the C package names (e.g., hip rocblas). The hipfort targets this provides are named the same as the targets from the C libraries, but are found in the hipfort namespace (e.g., hip::host becomes hipfort::host and roc::rocblas becomes hipfort::rocblas).

At the moment, targets are only provided for the AMD backend.