### PR TITLE
Rename hipfort::host to hipfort::hip

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -122,12 +122,12 @@ endmacro()
 
 find_package(hip)
 if(hip_FOUND)
-  add_library(hipfort-host INTERFACE)
-  add_library(hipfort::host ALIAS hipfort-host)
-  target_link_libraries(hipfort-host INTERFACE hipfort-amdgcn hip::host)
+  add_library(hipfort-hip INTERFACE)
+  add_library(hipfort::hip ALIAS hipfort-hip)
+  target_link_libraries(hipfort-hip INTERFACE hipfort-amdgcn hip::host)
   install(
     TARGETS
-      hipfort-host
+      hipfort-hip
     EXPORT hipfort-hip-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -141,7 +141,7 @@ if(hip_FOUND)
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
   )
 else()
-  message(STATUS "Skipping hipfort::host target export")
+  message(STATUS "Skipping hipfort::hip target export")
 endif()
 
 find_package(rocblas)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -122,28 +122,7 @@ endmacro()
 
 find_package(hip)
 if(hip_FOUND)
-  add_library(hipfort-hip INTERFACE)
-  add_library(hipfort::hip ALIAS hipfort-hip)
-  set_target_properties(hipfort-hip
-    PROPERTIES
-      EXPORT_NAME hip
-  )
-  target_link_libraries(hipfort-hip INTERFACE hipfort-amdgcn hip::host)
-  install(
-    TARGETS
-      hipfort-hip
-    EXPORT hipfort-hip-targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  )
-  install(
-    EXPORT hipfort-hip-targets
-    FILE hipfort-hip-targets.cmake
-    NAMESPACE hipfort::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
-  )
+  hipfort_add_component(hip hip::host)
 else()
   message(STATUS "Skipping hipfort::hip target export")
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -124,6 +124,10 @@ find_package(hip)
 if(hip_FOUND)
   add_library(hipfort-hip INTERFACE)
   add_library(hipfort::hip ALIAS hipfort-hip)
+  set_target_properties(hipfort-hip
+    PROPERTIES
+      EXPORT_NAME hip
+  )
   target_link_libraries(hipfort-hip INTERFACE hipfort-amdgcn hip::host)
   install(
     TARGETS


### PR DESCRIPTION
The name has no impact on the functionality, but the meaning of `hipfort::hip` is more obvious than `hipfort::host`.